### PR TITLE
Histogram fix

### DIFF
--- a/packages/client/lib/commands/LATENCY_HISTOGRAM.spec.ts
+++ b/packages/client/lib/commands/LATENCY_HISTOGRAM.spec.ts
@@ -1,48 +1,95 @@
-import { strict as assert } from 'assert';
-import testUtils, { GLOBAL } from '../test-utils';
-import LATENCY_HISTOGRAM from './LATENCY_HISTOGRAM';
-import { parseArgs } from './generic-transformers';
+import { strict as assert } from "assert";
+import testUtils, { GLOBAL } from "../test-utils";
+import LATENCY_HISTOGRAM from "./LATENCY_HISTOGRAM";
+import { parseArgs } from "./generic-transformers";
 
-describe('LATENCY HISTOGRAM', () => {
-  describe('transformArguments', () => {
-    it('filtered by command set', () => {
-      assert.deepStrictEqual(
-        parseArgs(LATENCY_HISTOGRAM, 'set'),
-        ['LATENCY', 'HISTOGRAM', 'set'],
-      );
+describe("LATENCY HISTOGRAM", () => {
+  describe("transformArguments", () => {
+    it("filtered by command set", () => {
+      assert.deepStrictEqual(parseArgs(LATENCY_HISTOGRAM, "set"), [
+        "LATENCY",
+        "HISTOGRAM",
+        "set",
+      ]);
     });
 
-    it('unfiltered', () => {
-      assert.deepStrictEqual(
-        parseArgs(LATENCY_HISTOGRAM),
-        ['LATENCY', 'HISTOGRAM'],
-      );
+    it("unfiltered", () => {
+      assert.deepStrictEqual(parseArgs(LATENCY_HISTOGRAM), [
+        "LATENCY",
+        "HISTOGRAM",
+      ]);
     });
   });
 
-  testUtils.testWithClient('unfiltered list', async client => {
-    await client.configResetStat();
-    await client.lPush('push-key', 'hello ');
-    await client.set('set-key', 'world!');
-    const histogram = await client.latencyHistogram();
-    const commands = ['config|resetstat', 'latency|histogram', 'set', 'lpush'];
-    for (const command of commands) {
-      assert.ok(histogram.includes(command));
-    }
-    assert.equal(histogram.length, 8);
-  }, GLOBAL.SERVERS.OPEN);
+  describe("RESP 2", () => {
+    testUtils.testWithClient(
+      "unfiltered list",
+      async (client) => {
+        await client.configResetStat();
+        await Promise.all([
+          client.lPush("push-key", "hello "),
+          client.set("set-key", "world!"),
+        ]);
+        const histogram = await client.latencyHistogram();
+        const commands = ["config|resetstat", "set", "lpush"];
+        for (const command of commands) {
+          assert.ok(typeof histogram[command]["calls"], "number");
+        }
+      },
+      GLOBAL.SERVERS.OPEN,
+    );
 
-  testUtils.testWithClient('filtered by a command list', async client => {
-    await client.configSet('latency-monitor-threshold', '100');
-    await client.set('set-key', 'hello');
-    const reply = await client.latencyHistogram('set');
-    assert.ok(Array.isArray(reply));
-    assert.equal(reply[0], 'set');
-    const histogram = reply[1];
-    assert.ok(Array.isArray(histogram));
-    assert.equal(histogram[0], 'calls');
-    assert.equal(typeof histogram[1], 'number');
-    assert.equal(histogram[2], 'histogram_usec');
-    assert.ok(Array.isArray(histogram[3]));
-  }, GLOBAL.SERVERS.OPEN);
+    testUtils.testWithClient(
+      "filtered by a command list",
+      async (client) => {
+        await client.configSet("latency-monitor-threshold", "100");
+        await client.set("set-key", "hello");
+        const histogram = await client.latencyHistogram("set");
+
+        assert.ok(typeof histogram.set["calls"], "number");
+      },
+      GLOBAL.SERVERS.OPEN,
+    );
+  });
+
+  describe("RESP 3", () => {
+    testUtils.testWithClient(
+      "unfiltered list",
+      async (client) => {
+        await client.configResetStat();
+        await Promise.all([
+          client.lPush("push-key", "hello "),
+          client.set("set-key", "world!"),
+        ]);
+        const histogram = await client.latencyHistogram();
+        const commands = ["config|resetstat", "set", "lpush"];
+        for (const command of commands) {
+          assert.ok(typeof histogram[command]["calls"], "number");
+        }
+      },
+      {
+        ...GLOBAL.SERVERS.OPEN,
+        clientOptions: {
+          RESP: 3,
+        },
+      },
+    );
+
+    testUtils.testWithClient(
+      "filtered by a command list",
+      async (client) => {
+        await client.configSet("latency-monitor-threshold", "100");
+        await client.set("set-key", "hello");
+        const histogram = await client.latencyHistogram("set");
+
+        assert.ok(typeof histogram.set["calls"], "number");
+      },
+      {
+        ...GLOBAL.SERVERS.OPEN,
+        clientOptions: {
+          RESP: 3,
+        },
+      },
+    );
+  });
 });

--- a/packages/client/lib/commands/LATENCY_HISTOGRAM.ts
+++ b/packages/client/lib/commands/LATENCY_HISTOGRAM.ts
@@ -1,15 +1,20 @@
 import { CommandParser } from '../client/parser';
-import {
-  ArrayReply, BlobStringReply, Command, NumberReply,
-  TuplesReply
-} from '../RESP/types';
+import { Command } from '../RESP/types';
+import { transformTuplesToMap } from './generic-transformers';
+
+type RawHistogram = [string, number, string, number[]];
+
+type Histogram = Record<string, {
+  calls: number;
+  histogram_usec: Record<string, number>;
+}>;
 
 export default {
   CACHEABLE: false,
   IS_READ_ONLY: true,
   /**
    * Constructs the LATENCY HISTOGRAM command
-   * 
+   *
    * @param parser - The command parser
    * @param commands - The list of redis commands to get histogram for
    * @see https://redis.io/docs/latest/commands/latency-histogram/
@@ -21,13 +26,20 @@ export default {
     }
     parser.push(...args);
   },
-  transformReply: undefined as unknown as () => ArrayReply<
-    BlobStringReply |
-    TuplesReply<[
-      BlobStringReply,
-      NumberReply,
-      BlobStringReply,
-      NumberReply[],
-    ]>
-  >
+  transformReply: {
+    2: (reply: (string | RawHistogram)[]): Histogram => {
+      const result: Histogram = {};
+      if (reply.length === 0) return result;
+      for (let i = 1; i < reply.length; i += 2) {
+        const histogram = reply[i] as RawHistogram;
+        const usec = transformTuplesToMap(histogram[3], n => n);
+        result[reply[i - 1] as string] = {
+          calls: histogram[1],
+          histogram_usec: usec,
+        };
+      }
+      return result;
+    },
+    3: undefined as unknown as () => Histogram
+  }
 } as const satisfies Command;


### PR DESCRIPTION
As per the [docs](https://redis.io/docs/latest/commands/latency-histogram/#return-information), `histogram_usec` is a map, not an array. We usually dont need to do anything for RESP 3 as the server correctly returns a map, but for resp 2 we need to transform the array to a map. We have a helper function for that: `transformTuplesToMap`
